### PR TITLE
Fix: Specify did as the parameter to metacat.get_file()

### DIFF
--- a/lfn2pfn.py
+++ b/lfn2pfn.py
@@ -48,7 +48,7 @@ def lfn2pfn_DUNE(scope, name, rse, rse_attrs, protocol_attrs):
         return didmd[md_key]
 
     lfn = scope + ':' + name
-    jsondata = metacat_client.get_file(name=lfn)
+    jsondata = metacat_client.get_file(did=lfn)
     metadata = jsondata["metadata"]
 
     # determine year from timestamps


### PR DESCRIPTION
The name of the argument was wrong. :)
With this change we could read and write files non-deterministically this afternoon. Thanks again, James. 