### PR TITLE
cache metacat.get_dataset() calls to reduce rucio->metacat traffic

### DIFF
--- a/permission.py
+++ b/permission.py
@@ -23,6 +23,7 @@ from rucio.core.lifetime_exception import list_exceptions
 from rucio.core.rse import list_rse_attributes
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.db.sqla.constants import IdentityType
+import functools
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -398,8 +399,12 @@ def _files_exist(lst):
     return len(files) == len(dids)
 
 
+@func_tools.lru_cache(maxsize=512)
+def _cached_get_dataset(did):
+    return metacat_client.get_dataset(did) is not None
+      
 def _dataset_exists(dataset):
-    return metacat_client.get_dataset(did=dataset["scope"].external+":"+dataset["name"]) is not None
+    return _cached_get_dataset(did=dataset["scope"].external+":"+dataset["name"]) is not None
 
 
 def perm_add_did(issuer: "InternalAccount", kwargs: dict[str, Any], *, session: "Optional[Session]" = None) -> bool:

--- a/permission.py
+++ b/permission.py
@@ -401,7 +401,7 @@ def _files_exist(lst):
 
 @func_tools.lru_cache(maxsize=512)
 def _cached_get_dataset(did):
-    return metacat_client.get_dataset(did) is not None
+    return metacat_client.get_dataset(did)
       
 def _dataset_exists(dataset):
     return _cached_get_dataset(did=dataset["scope"].external+":"+dataset["name"]) is not None


### PR DESCRIPTION
Currently 1/3 of the calls to DUNE metacat are the dataset_exists call in the DUNE Rucio policy, with mostly repeated requests.
This PR puts a [functools.lru_cache](https://docs.python.org/3/library/functools.html#functools.lru_cache) wrapper on those calls, so we shouldn't repeat any of the last 512 requests we've made in a given Rucio pod. 